### PR TITLE
Fix code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/inventory.rb
+++ b/inventory.rb
@@ -1,12 +1,12 @@
 require 'nokogiri'
-require 'open-uri'
+require 'net/http'
 require './item.rb'
 
 class Inventory
   attr_reader :weapons, :mods, :characters, :consumables, :gears
 
   def initialize(url)
-    doc = Nokogiri::HTML(URI.open(url))
+    doc = Nokogiri::HTML(Net::HTTP.get(URI.parse(url)))
     inventory = doc.css('div#inventory div#inventory_content')
     @weapons = inventory.css('div#weapons_content div.card').map{|v|Item.new(:weapon, v)}
     @mods = inventory.css('div#weapon_mods_content div.card').map{|v|Item.new(:mod, v)}


### PR DESCRIPTION
Fixes [https://github.com/jasonkim/ME3-Inventory-Sync/security/code-scanning/2](https://github.com/jasonkim/ME3-Inventory-Sync/security/code-scanning/2)

To fix the problem, we should replace the usage of `URI.open(url)` with a safer alternative. The recommended approach is to use an HTTP client to fetch the content of the URL. This avoids the potential security risk associated with `URI.open`.

We will:
1. Replace `URI.open(url)` with `Net::HTTP.get(URI.parse(url))`.
2. Ensure that the necessary `net/http` library is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
